### PR TITLE
Fix center issues

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,7 +18,7 @@ end
 function geometry(properties, position, size)
     if position == "top" or position == "bottom" or position == "center" then
         properties.height = size
-    end if position == "left" or position == "right" or positionn == "center" then
+    end if position == "left" or position == "right" or position == "center" then
         properties.width = size
     end
 

--- a/init.lua
+++ b/init.lua
@@ -44,9 +44,11 @@ end
 
 function new(name, c)
     local app = apps[name]
+    local props = app.properties
     app.client = c
 
     awful.rules.execute(c, defaultProperties)
+    awful.rules.execute(c, {width=props.width, height=props.height})
     awful.rules.execute(c, app.properties)
     c:connect_signal("unfocus", function() c.minimized = true end)
 

--- a/init.lua
+++ b/init.lua
@@ -49,7 +49,7 @@ function new(name, c)
 
     awful.rules.execute(c, defaultProperties)
     awful.rules.execute(c, {width=props.width, height=props.height})
-    awful.rules.execute(c, app.properties)
+    awful.rules.execute(c, props)
     c:connect_signal("unfocus", function() c.minimized = true end)
 
     if app.callback ~= nil then app.callback(c) end


### PR DESCRIPTION
This PR fixed two bugs:
* Specifying size on centered windows only affected width
* Windows where centered before they where resized which caused them not to be centered

To replicate issues:
```lua
    awful.key({ modkey }, "p",
          function () poppin.pop("terminal", "urxvt", "center", 200) end,
          {description = "Opens a poppin' terminal", group = "poppin"}),

```